### PR TITLE
math: add more constants

### DIFF
--- a/stdlib/math/constants.aspl
+++ b/stdlib/math/constants.aspl
@@ -53,18 +53,22 @@ function feigenbaum_alpha() returns double{
 	return 2.502907875095892d
 }
 
+[public]
 function feigenbaum_delta() returns double{
 	return 4.669201609102990d
 }
 
+[public]
 function catalan_constant() returns double{
 	return 0.91596559417721d
 }
 
+[public]
 function khinchin_constant() returns double{
 	return 2.685452001065306d
 }
 
+[public]
 function glaisher_kinkelin() returns double{
 	return 1.282427129100622d
 }


### PR DESCRIPTION
Add the following math constants
- Golden Ratio
- Square Root of 2
- Square Root of 3
- Square Root of 5
- Natural Log of 2
- Natural Log of 10
- Euler–Mascheroni
- Apéry’s Constant
- Catalan’s Constant
- Feigenbaum Alpha
- Feigenbaum Delta
- Khinchin’s Constant
- Glaisher–Kinkelin